### PR TITLE
Develop disable iboutlet trailing closure

### DIFF
--- a/Sources/UIViewKit/UIViewDSL+IBOutlet.swift
+++ b/Sources/UIViewKit/UIViewDSL+IBOutlet.swift
@@ -23,48 +23,48 @@ extension UIViewDSL where Self: UIView {
     }
     
     @discardableResult
-    public func ibOutlet(_ outlet: inout Self?, @UIViewBuilder _ content: () -> [UIView]) -> Self {
-        outlet = self
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
-    
-    @discardableResult
-    public func ibOutlet(_ outlet: inout Self?, @UIViewBuilder _ content: (UIView) -> [UIView]) -> Self {
-        outlet = self
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
-    
-    @discardableResult
-    public func ibOutlet(_ outlet: inout Self, @UIViewBuilder _ content: () -> [UIView]) -> Self {
-        outlet = self
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
-    
-    @discardableResult
-    public func ibOutlet(_ outlet: inout Self, @UIViewBuilder _ content: (UIView) -> [UIView]) -> Self {
-        outlet = self
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
-
-    @discardableResult
     public func ibOutlet(in outlet: inout [Self]) -> Self {
         outlet.append(self)
         return self
     }
     
     @discardableResult
-    public func ibOutlet(in outlet: inout [Self], @UIViewBuilder _ content: () -> [UIView]) -> Self {
+    func ibOutlet(_ outlet: inout Self?, @UIViewBuilder _ content: () -> [UIView]) -> Self {
+        outlet = self
+        UIViewDSLEngine.shared.addSubviews(content, to: self)
+        return self
+    }
+    
+    @discardableResult
+    func ibOutlet(_ outlet: inout Self?, @UIViewBuilder _ content: (UIView) -> [UIView]) -> Self {
+        outlet = self
+        UIViewDSLEngine.shared.addSubviews(content, to: self)
+        return self
+    }
+    
+    @discardableResult
+    func ibOutlet(_ outlet: inout Self, @UIViewBuilder _ content: () -> [UIView]) -> Self {
+        outlet = self
+        UIViewDSLEngine.shared.addSubviews(content, to: self)
+        return self
+    }
+    
+    @discardableResult
+    func ibOutlet(_ outlet: inout Self, @UIViewBuilder _ content: (UIView) -> [UIView]) -> Self {
+        outlet = self
+        UIViewDSLEngine.shared.addSubviews(content, to: self)
+        return self
+    }
+    
+    @discardableResult
+    func ibOutlet(in outlet: inout [Self], @UIViewBuilder _ content: () -> [UIView]) -> Self {
         outlet.append(self)
         UIViewDSLEngine.shared.addSubviews(content, to: self)
         return self
     }
     
     @discardableResult
-    public func ibOutlet(in outlet: inout [Self], @UIViewBuilder _ content: (UIView) -> [UIView]) -> Self {
+    func ibOutlet(in outlet: inout [Self], @UIViewBuilder _ content: (UIView) -> [UIView]) -> Self {
         outlet.append(self)
         UIViewDSLEngine.shared.addSubviews(content, to: self)
         return self

--- a/Sources/UIViewKit/UIViewDSL+IBOutlet.swift
+++ b/Sources/UIViewKit/UIViewDSL+IBOutlet.swift
@@ -27,46 +27,4 @@ extension UIViewDSL where Self: UIView {
         outlet.append(self)
         return self
     }
-    
-    @discardableResult
-    func ibOutlet(_ outlet: inout Self?, @UIViewBuilder _ content: () -> [UIView]) -> Self {
-        outlet = self
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
-    
-    @discardableResult
-    func ibOutlet(_ outlet: inout Self?, @UIViewBuilder _ content: (UIView) -> [UIView]) -> Self {
-        outlet = self
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
-    
-    @discardableResult
-    func ibOutlet(_ outlet: inout Self, @UIViewBuilder _ content: () -> [UIView]) -> Self {
-        outlet = self
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
-    
-    @discardableResult
-    func ibOutlet(_ outlet: inout Self, @UIViewBuilder _ content: (UIView) -> [UIView]) -> Self {
-        outlet = self
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
-    
-    @discardableResult
-    func ibOutlet(in outlet: inout [Self], @UIViewBuilder _ content: () -> [UIView]) -> Self {
-        outlet.append(self)
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
-    
-    @discardableResult
-    func ibOutlet(in outlet: inout [Self], @UIViewBuilder _ content: (UIView) -> [UIView]) -> Self {
-        outlet.append(self)
-        UIViewDSLEngine.shared.addSubviews(content, to: self)
-        return self
-    }
 }

--- a/Tests/UIViewKitTests/IBOutletTests.swift
+++ b/Tests/UIViewKitTests/IBOutletTests.swift
@@ -40,7 +40,7 @@ class IBOutletTests: XCTestCase {
         
         var view = UIView()
         
-        let newView = UIView().ibOutlet(&view) {
+        let newView = UIView().ibOutlet(&view).ibSubviews {
             UIView()
         }
     
@@ -51,7 +51,7 @@ class IBOutletTests: XCTestCase {
         
         var view = UIView()
         
-        let newView = UIView().ibOutlet(&view) { _ in
+        let newView = UIView().ibOutlet(&view).ibSubviews { _ in
             UIView()
         }
     
@@ -61,7 +61,7 @@ class IBOutletTests: XCTestCase {
     func testIBOutletInWithTrailingClosureOfIbSubviews() throws {
         var views: [UIView] = []
         
-        let newView = UIView().ibOutlet(in: &views) {
+        let newView = UIView().ibOutlet(in: &views).ibSubviews {
             UIView()
         }
         
@@ -72,7 +72,7 @@ class IBOutletTests: XCTestCase {
     func testIBOutletInWithTrailingClosureOfIbSubviewsAndSuperview() throws {
         var views: [UIView] = []
         
-        let newView = UIView().ibOutlet(in: &views) { _ in
+        let newView = UIView().ibOutlet(in: &views).ibSubviews { _ in
             UIView()
         }
         
@@ -83,7 +83,7 @@ class IBOutletTests: XCTestCase {
     func testIBOutletWithForceUnwrapWithTrailingClosureOfIbSubviews() async throws {
         var view: UIView!
         
-        let newView = UIView().ibOutlet(&view) {
+        let newView = UIView().ibOutlet(&view).ibSubviews {
             UIView()
         }
         
@@ -93,7 +93,7 @@ class IBOutletTests: XCTestCase {
     func testIBOutletWithForceUnwrapWithTrailingClosureOfIbSubviewsAndSuperview() async throws {
         var view: UIView!
         
-        let newView = UIView().ibOutlet(&view) { _ in
+        let newView = UIView().ibOutlet(&view).ibSubviews { _ in
             UIView()
         }
         


### PR DESCRIPTION
**Problem:** 

Using outlets within implicit ibSubviews results in the following error:

> Thread 1: Simultaneous accesses to 0x1041061f8, but modification requires exclusive access.

This issue arises in cases like the following:

```
var view: UIView!
UIView().ibOutlet(&view) {
   UILabel().ibAttributes {
       $0.ibConstraints(to: view, guide: .view, anchors: .all) // refrence to view from argument and trailing closure causes the error
   }
}
```

**Cause:**

The problem is due to how the Swift manages access to memory when when passing a variable as an inout parameter to a function and also accessing it inside the function (like reading it in trailing closure) at the same time.

**Solution:**

To mitigate this confusion, especially for those new to the DSL, I've decided to deprecate and remove the ibOutlet functions that use a trailing closure for building subviews.

After this change, building subviews after using ibOutlet will look like this:

```
UIView().ibOutlet(&totoView).ibSubviews {
    UIView()
}

// OR

// The '()' is shorthand to 'callAsFunction':
UIView().ibOutlet(&totoView)() {
    UIView()
}

```