### PR TITLE
Add ibOutlet variants for views and constraints

### DIFF
--- a/Sources/UIViewKit/FoundationExtensions/NSObjectProtocol+ibApply.swift
+++ b/Sources/UIViewKit/FoundationExtensions/NSObjectProtocol+ibApply.swift
@@ -1,0 +1,17 @@
+//
+//  NSObjectProtocol+ibApply.swift
+//  UIViewKit
+//
+//  Created by blz on 22/08/2025.
+//
+
+import Foundation
+
+extension NSObjectProtocol {
+    
+    public func ibApply(_ block: (Self) -> Void) -> Self {
+        block(self);
+        return self
+    }
+
+}

--- a/Sources/UIViewKit/UIViewDSL/UIViewDSL+IBOutlet.swift
+++ b/Sources/UIViewKit/UIViewDSL/UIViewDSL+IBOutlet.swift
@@ -26,4 +26,23 @@ extension UIViewDSL where Self: UIView {
         outlet.append(self)
         return self
     }
+
+    @discardableResult
+    public func ibOutlets(_ block: (Self) -> Void) -> Self {
+        block(self)
+        return self
+    }
+    
+    @discardableResult
+    public func ibOutlet<Owner: Any>(_ owner: Owner?, _ property: ReferenceWritableKeyPath<Owner, Self>) -> Self {
+        owner?[keyPath: property] = self
+        return self
+    }
+    
+    @discardableResult
+    public func ibOutlet<Owner: Any>(_ owner: Owner?, _ property: ReferenceWritableKeyPath<Owner, Self?>) -> Self {
+        owner?[keyPath: property] = self
+        return self
+    }
+    
 }

--- a/Sources/UIViewKit/UIViewDSL/UIViewDSL+NSLayoutConstraint.swift
+++ b/Sources/UIViewKit/UIViewDSL/UIViewDSL+NSLayoutConstraint.swift
@@ -37,6 +37,24 @@ extension NSLayoutConstraint {
         outlet = self
         return self
     }
+    
+    @discardableResult
+    public func ibOutlet<Owner: Any>(_ owner: Owner?, _ property: ReferenceWritableKeyPath<Owner, NSLayoutConstraint>) -> Self {
+        owner?[keyPath: property] = self
+        return self
+    }
+    
+    @discardableResult
+    public func ibOutlet<Owner: Any>(_ owner: Owner?, _ property: ReferenceWritableKeyPath<Owner, NSLayoutConstraint?>) -> Self {
+        owner?[keyPath: property] = self
+        return self
+    }
+    
+    @discardableResult
+    public func ibOutlets(_ block: (Self) -> Void) -> Self {
+        block(self)
+        return self
+    }
 
     @discardableResult
     public func ibShouldBeArchived(_ shouldBeArchived: Bool) -> Self {

--- a/Tests/UIViewKitTests/FoundationExtensionsTests.swift
+++ b/Tests/UIViewKitTests/FoundationExtensionsTests.swift
@@ -1,0 +1,20 @@
+//
+//  FoundationExtensionsTests.swift
+//  UIViewKit
+//
+//  Created by blz on 22/08/2025.
+//
+
+import Testing
+import Foundation
+
+@Test func ibApply() throws {
+    let newValue = "test"
+    let obj = NSObject()
+    try #require(obj.accessibilityLabel == nil)
+    _ = obj.ibApply {
+        $0.accessibilityLabel = newValue
+    }
+    #expect(obj.accessibilityLabel == newValue)
+}
+

--- a/Tests/UIViewKitTests/IBConstraintsTests.swift
+++ b/Tests/UIViewKitTests/IBConstraintsTests.swift
@@ -123,4 +123,30 @@ class ibConstraintsTests: XCTestCase {
 
         XCTAssertEqual(view.constraints.count, 40)
     }
+    
+    class MyView: UIView {
+        var heightConstraint: NSLayoutConstraint!
+    }
+    
+    class MyViewWithHeightConstraintOptional: UIView {
+        var heightConstraint: NSLayoutConstraint!
+    }
+
+    func testConstraintIBOutletKeyPathOptionalOwnerAndDestinationForced() throws {
+        let myView: MyView? = .init()
+        UIView().heightAnchor.constraint(equalToConstant: 1).ibOutlet(myView, \.heightConstraint)
+        XCTAssertEqual(myView?.heightConstraint.constant, 1)
+    }
+    
+    func testConstraintIBOutletKeyPathOptionalOwnerAndDestinationOptional() throws {
+        let myView: MyViewWithHeightConstraintOptional? = .init()
+        UIView().heightAnchor.constraint(equalToConstant: 1).ibOutlet(myView, \.heightConstraint)
+        XCTAssertEqual(myView?.heightConstraint.constant, 1)
+    }
+    
+    func testConstraintIBOutlets() throws {
+        let myView: MyView? = .init()
+        UIView().heightAnchor.constraint(equalToConstant: 1).ibOutlets { myView?.heightConstraint = $0 }
+        XCTAssertEqual(myView?.heightConstraint.constant, 1)
+    }
 }

--- a/Tests/UIViewKitTests/IBOutletTests.swift
+++ b/Tests/UIViewKitTests/IBOutletTests.swift
@@ -99,5 +99,30 @@ class IBOutletTests: XCTestCase {
 
         XCTAssertEqual(view, newView)
     }
+    
+    class MyView {
+        var label: UILabel!
+    }
+    class MyViewWithOptionalLabel {
+        var label: UILabel?
+    }
+
+    func testIBOutletKeyPathWithOptionalOwner() throws {
+        let myView: MyView? = .init()
+        UILabel().ibOutlet(myView, \.label).ibAttributes { $0.tag = 1 }
+        XCTAssertEqual(myView?.label.tag, 1)
+    }
+    
+    func testIBOutletKeyPathWithOwnerOptionalAndLabelOptional() throws {
+        let myView: MyViewWithOptionalLabel? = .init()
+        UILabel().ibOutlet(myView, \.label).ibAttributes { $0.tag = 1 }
+        XCTAssertEqual(myView?.label?.tag, 1)
+    }
+    
+    func testIBOutlets() throws {
+        let myView: MyViewWithOptionalLabel? = .init()
+        UILabel().ibOutlets { myView?.label = $0 }.ibAttributes { $0.tag = 1 }
+        XCTAssertEqual(myView?.label?.tag, 1)
+    }
 
 }


### PR DESCRIPTION
which allows optional owner. Add ibApply for applying block changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added fluent helper to configure objects inline and continue chaining.
  * Introduced APIs to bind views and layout constraints to owning objects via key paths, supporting both optional owners and optional properties.
  * Extended the UIView DSL with convenience outlets and inline customization hooks.

* Tests
  * Added comprehensive unit tests for the new configuration and binding helpers across NSObject, UIView, and NSLayoutConstraint, including optional-owner and optional-destination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->