### PR TITLE
Add support for user's snapFrames for IBPreviewFreeForm

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "codecalltracker",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Adobels/CodeCallTracker.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "1d27da6706466a5b83bdb0f4097fc86f678b146f"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "UIViewKit", targets: ["UIViewKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Adobels/CodeCallTracker.git", exact: "1d27da6706466a5b83bdb0f4097fc86f678b146f")
+        .package(url: "https://github.com/Adobels/CodeCallTracker.git", revision: "1d27da6706466a5b83bdb0f4097fc86f678b146f")
     ],
     targets: [
         .target(name: "UIViewKit", dependencies: ["CodeCallTracker"]),

--- a/Package.swift
+++ b/Package.swift
@@ -11,14 +11,11 @@ let package = Package(
     products: [
         .library(name: "UIViewKit", targets: ["UIViewKit"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/Adobels/CodeCallTracker.git", exact: "1d27da6706466a5b83bdb0f4097fc86f678b146f")
+    ],
     targets: [
-        .target(
-            name: "UIViewKit"
-        ),
-        .testTarget(
-            name: "UIViewKitTests",
-            dependencies: [
-                "UIViewKit"
-            ])
+        .target(name: "UIViewKit", dependencies: ["CodeCallTracker"]),
+        .testTarget(name: "UIViewKitTests", dependencies: ["UIViewKit"])
     ]
 )

--- a/Sources/UIViewKit/IBPreviews/IBRepresentables.swift
+++ b/Sources/UIViewKit/IBPreviews/IBRepresentables.swift
@@ -8,8 +8,22 @@
 import UIKit
 import SwiftUI
 
-@available(iOS, introduced: 13, obsoleted: 17)
-public struct IBRepresentableViewController: UIViewControllerRepresentable {
+public func IBPreviewRepresentable(view: UIView) -> some UIViewRepresentable {
+    IBRepresentableView(view)
+}
+
+public func IBPreviewRepresentable(_ viewMaker: @escaping () -> UIView) -> some UIViewRepresentable {
+    IBRepresentableView(viewMaker)
+}
+public func IBPreviewRepresentable(viewController: UIViewController) -> some UIViewControllerRepresentable {
+    IBRepresentableViewController(viewController)
+}
+
+public func IBPreviewRepresentable(_ viewControllerMaker: @escaping () -> UIViewController) -> some UIViewControllerRepresentable {
+    IBRepresentableViewController(viewControllerMaker)
+}
+
+private struct IBRepresentableViewController: UIViewControllerRepresentable {
 
     public typealias UIViewControllerType = UIViewController
 
@@ -30,8 +44,7 @@ public struct IBRepresentableViewController: UIViewControllerRepresentable {
     public func updateUIViewController(_ uiViewController: UIViewController, context: Context) { }
 }
 
-@available(iOS, introduced: 13, obsoleted: 17)
-public struct IBRepresentableView: UIViewRepresentable {
+private struct IBRepresentableView: UIViewRepresentable {
     
     public typealias UIViewType = UIView
     

--- a/Sources/UIViewKit/UIViewKit.swift
+++ b/Sources/UIViewKit/UIViewKit.swift
@@ -10,3 +10,4 @@
 
 @_exported import UIKit
 @_exported import SwiftUI
+@_exported import CodeCallTracker


### PR DESCRIPTION
- Include CodeCallTracker framework in the project and export it for users
- Add support for user-defined snapFrames in IBPreviewFreeForm
- Remove availability constraints from IBPreviewRepresentable to make it easier to convert UIKit views to SwiftUI and apply modifiers on them