### PR TITLE
Rename result builders to @UIViewBuilder and @AutoLayoutBuilder

### DIFF
--- a/Sources/UIViewKit/IBPreviews/IBFreeForm.SnapFrame.swift
+++ b/Sources/UIViewKit/IBPreviews/IBFreeForm.SnapFrame.swift
@@ -1,0 +1,88 @@
+//
+//  IBFreeForm.SnapFrame.swift
+//  UIViewKit
+//
+//  Created by Blazej SLEBODA on 30/01/2026.
+//
+
+import UIKit.UIColor
+
+extension IBFreeForm {
+
+    public struct SnapFrame {
+        let title: String
+        let size: CGSize
+        let tintColor: UIColor
+        let borderWidth: CGFloat
+
+        public init(title: String = "\(Self.self)", size: CGSize, tintColor: UIColor? = nil, borderWidth: CGFloat = 1) {
+            self.title = title
+            self.size = size
+            if let tintColor { self.tintColor = tintColor } else {
+                self.tintColor = [
+                    .systemRed, .systemBlue, .systemGreen, .systemOrange,
+                    .systemPurple, .systemPink, .systemTeal, .systemIndigo,
+                    .systemYellow, .brown, .cyan, .magenta, .darkGray
+                ].randomElement()!
+            }
+            self.borderWidth = borderWidth
+        }
+    }
+
+}
+
+public extension IBFreeForm.SnapFrame {
+    // MARK: – SE
+    static var iPhoneSE1: Self { .init(title: "iPhone SE (1st gen)", size: .init(width: 320, height: 568)) }
+    static var iPhoneSE2 : Self { .init(title: "iPhone SE (2nd gen)", size: .init(width: 375, height: 667)) }
+    static var iPhoneSE3: Self { .init(title: "iPhone SE (3rd gen)", size: .init(width: 375, height: 667)) }
+    // MARK: – Classic
+    static var iPhone6: Self { .init(title: "iPhone 6", size: .init(width: 375, height: 667)) }
+    static var iPhone6Plus: Self { .init(title: "iPhone 6 Plus", size: .init(width: 414, height: 736)) }
+    static var iPhone6s: Self { .init(title: "iPhone 6s", size: .init(width: 375, height: 667)) }
+    static var iPhone6sPlus: Self { .init(title: "iPhone 6s Plus", size: .init(width: 414, height: 736)) }
+    static var iPhone7: Self { .init(title: "iPhone 7", size: .init(width: 375, height: 667)) }
+    static var iPhone7Plus: Self { .init(title: "iPhone 7 Plus", size: .init(width: 414, height: 736)) }
+    static var iPhone8: Self { .init(title: "iPhone 8", size: .init(width: 375, height: 667)) }
+    static var iPhone8Plus: Self { .init(title: "iPhone 8 Plus", size: .init(width: 414, height: 736)) }
+    // MARK: – X family
+    static var iPhoneX: Self { .init(title: "iPhone X", size: .init(width: 375, height: 812)) }
+    static var iPhoneXS: Self { .init(title: "iPhone XS", size: .init(width: 375, height: 812)) }
+    static var iPhoneXSMax: Self { .init(title: "iPhone XS Max", size: .init(width: 414, height: 896)) }
+    static var iPhoneXR: Self { .init(title: "iPhone XR", size: .init(width: 414, height: 896)) }
+    // MARK: – 11
+    static var iPhone11: Self { .init(title: "iPhone 11", size: .init(width: 414, height: 896)) }
+    static var iPhone11Pro: Self { .init(title: "iPhone 11 Pro", size: .init(width: 375, height: 812)) }
+    static var iPhone11ProMax: Self { .init(title: "iPhone 11 Pro Max", size: .init(width: 414, height: 896)) }
+    // MARK: – 12
+    static var iPhone12Mini: Self { .init(title: "iPhone 12 mini", size: .init(width: 360, height: 780)) }
+    static var iPhone12: Self { .init(title: "iPhone 12", size: .init(width: 390, height: 844)) }
+    static var iPhone12Pro: Self { .init(title: "iPhone 12 Pro", size: .init(width: 390, height: 844)) }
+    static var iPhone12ProMax: Self { .init(title: "iPhone 12 Pro Max", size: .init(width: 428, height: 926)) }
+    // MARK: – 13
+    static var iPhone13Mini: Self { .init(title: "iPhone 13 mini", size: .init(width: 375, height: 812)) }
+    static var iPhone13: Self { .init(title: "iPhone 13", size: .init(width: 390, height: 844)) }
+    static var iPhone13Pro: Self { .init(title: "iPhone 13 Pro", size: .init(width: 390, height: 844)) }
+    static var iPhone13ProMax: Self { .init(title: "iPhone 13 Pro Max", size: .init(width: 428, height: 926)) }
+    // MARK: – 14
+    static var iPhone14: Self { .init(title: "iPhone 14", size: .init(width: 390, height: 844)) }
+    static var iPhone14Plus: Self { .init(title: "iPhone 14 Plus", size: .init(width: 428, height: 926)) }
+    static var iPhone14Pro: Self { .init(title: "iPhone 14 Pro", size: .init(width: 393, height: 852)) }
+    static var iPhone14ProMax: Self { .init(title: "iPhone 14 Pro Max", size: .init(width: 430, height: 932)) }
+    // MARK: – 15
+    static var iPhone15: Self { .init(title: "iPhone 15", size: .init(width: 393, height: 852)) }
+    static var iPhone15Plus: Self { .init(title: "iPhone 15 Plus", size: .init(width: 430, height: 932)) }
+    static var iPhone15Pro: Self { .init(title: "iPhone 15 Pro", size: .init(width: 393, height: 852)) }
+    static var iPhone15ProMax: Self { .init(title: "iPhone 15 Pro Max", size: .init(width: 430, height: 932)) }
+    // MARK: – 16
+    static var iPhone16: Self { .init(title: "iPhone 16", size: .init(width: 393, height: 852)) }
+    static var iPhone16Plus: Self { .init(title: "iPhone 16 Plus", size: .init(width: 430, height: 932)) }
+    static var iPhone16Pro: Self { .init(title: "iPhone 16 Pro", size: .init(width: 402, height: 874)) }
+    static var iPhone16ProMax: Self { .init(title: "iPhone 16 Pro Max", size: .init(width: 440, height: 956)) }
+    // MARK: – 17
+    static var iPhone17: Self { .init(title: "iPhone 17", size: .init(width: 402, height: 874)) }
+    static var iPhone17Pro: Self { .init(title: "iPhone 17 Pro", size: .init(width: 402, height: 874)) }
+    static var iPhone17ProMax: Self { .init(title: "iPhone 17 Pro Max", size: .init(width: 440, height: 956)) }
+    // MARK: – Air
+    static var iPhoneAir: Self { .init(title: "iPhone Air", size: .init(width: 420, height: 912)) }
+}

--- a/Sources/UIViewKit/IBPreviews/IBFreeForm.swift
+++ b/Sources/UIViewKit/IBPreviews/IBFreeForm.swift
@@ -17,32 +17,32 @@ public class IBFreeForm: ViewControllerFreeFormContainer {
         fatalError()
     }
 
-    public init(snapFrames: (any SnapFrame)..., view: UIView) {
+    public init(snapFrames: (SnapFrame)..., view: UIView) {
         super.init(snapFrames: snapFrames)
         self.viewMaker = { view }
     }
 
-    public init(snapFrames: (any SnapFrame)..., viewMaker: @escaping  () -> UIView) {
+    public init(snapFrames: (SnapFrame)..., viewMaker: @escaping  () -> UIView) {
         super.init(snapFrames: snapFrames)
         self.viewMaker = viewMaker
     }
 
-    public init(snapFrames: (any SnapFrame)..., viewController: UIViewController) {
+    public init(snapFrames: (SnapFrame)..., viewController: UIViewController) {
         super.init(snapFrames: snapFrames)
         self.viewControllerMaker = { viewController }
     }
 
-    public init(snapFrames: (any SnapFrame)..., viewControllerMaker: @escaping  () -> UIViewController) {
+    public init(snapFrames: (SnapFrame)..., viewControllerMaker: @escaping  () -> UIViewController) {
         super.init(snapFrames: snapFrames)
         self.viewControllerMaker = viewControllerMaker
     }
 
-    public init(snapFrames: (any SnapFrame)..., view: some View) {
+    public init(snapFrames: (SnapFrame)..., view: some View) {
         super.init(snapFrames: snapFrames)
         self.viewControllerMaker = { UIHostingController(rootView: view) }
     }
 
-    public init(snapFrames: (any SnapFrame)..., viewMaker: @escaping  () -> some View) {
+    public init(snapFrames: (SnapFrame)..., viewMaker: @escaping  () -> some View) {
         super.init(snapFrames: snapFrames )
         self.viewControllerMaker = { UIHostingController(rootView: viewMaker()) }
     }
@@ -76,11 +76,24 @@ public class IBFreeForm: ViewControllerFreeFormContainer {
 
 extension IBFreeForm {
 
-    public protocol SnapFrame where Self: SnapFrame {
-        var size: CGSize { get }
-        var title: String { get }
-        var tintColor: UIColor { get }
-        var borderWidth: CGFloat { get }
+    public struct SnapFrame {
+        let title: String
+        let size: CGSize
+        let tintColor: UIColor
+        let borderWidth: CGFloat
+
+        public init(title: String = "\(Self.self)", size: CGSize, tintColor: UIColor? = nil, borderWidth: CGFloat = 1) {
+            self.title = title
+            self.size = size
+            if let tintColor { self.tintColor = tintColor } else {
+                self.tintColor = [
+                    .systemRed, .systemBlue, .systemGreen, .systemOrange,
+                    .systemPurple, .systemPink, .systemTeal, .systemIndigo,
+                    .systemYellow, .brown, .cyan, .magenta, .darkGray
+                ].randomElement()!
+            }
+            self.borderWidth = borderWidth
+        }
     }
 
 }

--- a/Sources/UIViewKit/IBPreviews/IBFreeForm.swift
+++ b/Sources/UIViewKit/IBPreviews/IBFreeForm.swift
@@ -74,30 +74,6 @@ public class IBFreeForm: ViewControllerFreeFormContainer {
 
 }
 
-extension IBFreeForm {
-
-    public struct SnapFrame {
-        let title: String
-        let size: CGSize
-        let tintColor: UIColor
-        let borderWidth: CGFloat
-
-        public init(title: String = "\(Self.self)", size: CGSize, tintColor: UIColor? = nil, borderWidth: CGFloat = 1) {
-            self.title = title
-            self.size = size
-            if let tintColor { self.tintColor = tintColor } else {
-                self.tintColor = [
-                    .systemRed, .systemBlue, .systemGreen, .systemOrange,
-                    .systemPurple, .systemPink, .systemTeal, .systemIndigo,
-                    .systemYellow, .brown, .cyan, .magenta, .darkGray
-                ].randomElement()!
-            }
-            self.borderWidth = borderWidth
-        }
-    }
-
-}
-
 public class ViewControllerFreeFormContainer: UIViewController {
 
     var containerView: UIView!

--- a/Sources/UIViewKit/UIViewDSL/ResultBuilder/UIViewDSL+AutoLayoutBuilder.swift
+++ b/Sources/UIViewKit/UIViewDSL/ResultBuilder/UIViewDSL+AutoLayoutBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  UIViewDSL+IBArrayOfNSLayoutConstraintBuilder.swift
+//  UIViewDSL+AutoLayoutBuilder.swift
 //  UIViewKit
 //
 //  Created by blz on 12/09/2025.
@@ -8,7 +8,7 @@
 import UIKit
 
 @resultBuilder
-public enum IBArrayOfNSLayoutConstraintBuilder {
+public enum AutoLayoutBuilder {
 
     public static func buildBlock(_ components: [NSLayoutConstraint]...) -> [NSLayoutConstraint] {
         components.flatMap { $0 }

--- a/Sources/UIViewKit/UIViewDSL/ResultBuilder/UIViewDSL+UIViewBuilder.swift
+++ b/Sources/UIViewKit/UIViewDSL/ResultBuilder/UIViewDSL+UIViewBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  UIViewDSL+IBArrayOfUIViewBuilder.swift
+//  UIViewDSL+UIViewBuilder.swift
 //  UIViewKit
 //
 //  Created by Blazej SLEBODA on 29/09/2023.
@@ -8,7 +8,7 @@
 import UIKit
 
 @resultBuilder
-public enum IBArrayOfUIViewBuilder {
+public enum UIViewBuilder {
 
     public static func buildBlock(_ components: [UIView]...) -> [UIView] {
         components.flatMap { $0 }

--- a/Sources/UIViewKit/UIViewDSL/UIViewDSL+IBAttributes.swift
+++ b/Sources/UIViewKit/UIViewDSL/UIViewDSL+IBAttributes.swift
@@ -10,7 +10,7 @@ import UIKit
 extension UIViewDSL {
 
     @discardableResult
-    public func ibAttributes(@IBArrayOfNSLayoutConstraintBuilder _ block: (Self) -> [NSLayoutConstraint]) -> Self {
+    public func ibAttributes(@AutoLayoutBuilder _ block: (Self) -> [NSLayoutConstraint]) -> Self {
         let constraintsGenerated = block(self)
         UIViewDSLEngine.shared.addConstraints(for: self, constraints: constraintsGenerated)
         return self

--- a/Sources/UIViewKit/UIViewDSL/UIViewDSL+IBSubviews.swift
+++ b/Sources/UIViewKit/UIViewDSL/UIViewDSL+IBSubviews.swift
@@ -10,13 +10,13 @@ import UIKit
 extension UIViewDSL {
 
     @discardableResult
-    public func ibSubviews(@IBArrayOfUIViewBuilder _ content: () -> [UIView]) -> Self {
+    public func ibSubviews(@UIViewBuilder _ content: () -> [UIView]) -> Self {
         UIViewDSLEngine.shared.addSubviews(content, to: self)
         return self
     }
 
     @discardableResult
-    public func ibSubviews(@IBArrayOfUIViewBuilder _ content: (Self) -> [UIView]) -> Self {
+    public func ibSubviews(@UIViewBuilder _ content: (Self) -> [UIView]) -> Self {
         let contentWrapper: (UIView) -> [UIView] = { arg1 in
             content(arg1 as! Self) // swiftlint:disable:this force_cast
         }

--- a/Sources/UIViewKit/UIViewDSL/UIViewDSL+NSLayoutConstraint.swift
+++ b/Sources/UIViewKit/UIViewDSL/UIViewDSL+NSLayoutConstraint.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension NSLayoutConstraint {
 
-    static public func ibActivate(@IBArrayOfNSLayoutConstraintBuilder _ block: () -> [NSLayoutConstraint]) {
+    static public func ibActivate(@AutoLayoutBuilder _ block: () -> [NSLayoutConstraint]) {
         let constraints = block()
         activate(constraints)
     }


### PR DESCRIPTION
New names @UIViewBuilder and @AutoLayoutBuilder, follow the conventions used by SwiftUI builders, such as @ViewBuilder. They are easier to remember and reason about.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal builder naming conventions across the UIViewKit framework for enhanced code consistency and improved architectural clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->